### PR TITLE
Potential fix for code scanning alert no. 1: Application backup allowed

### DIFF
--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Potential fix for [https://github.com/o2ter/frosty-native/security/code-scanning/1](https://github.com/o2ter/frosty-native/security/code-scanning/1)

To fix the problem, we need to set the `android:allowBackup` attribute to `false` in the Android manifest file. This will disable automatic backups for the application, thereby reducing the risk of sensitive data being extracted by attackers.

The best way to fix this issue without changing existing functionality is to modify the `android:allowBackup` attribute in the `<application>` element of the `template/android/app/src/main/AndroidManifest.xml` file. Specifically, we need to change the value of `android:allowBackup` from `true` to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
